### PR TITLE
Fix colorbar scaling for localization density plot, add note about input units, full FBME likelihood function

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,17 @@ dynamics.
 
 See the [Documentation](https://saspt.readthedocs.io/en/latest/) for more info. 
 
-To install: `pip install saspt`
+## Install
+
+Method 1 (recommended): install from PyPI:
+```
+  pip install saspt
+```
+
+Method 2: install from source
+
+```
+  git clone https://github.com/alecheckert/saspt
+  cd saspt
+  pip install -e .
+```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ dynamics.
 
 See the [Documentation](https://saspt.readthedocs.io/en/latest/) for more info. 
 
+See the `examples` directory for usage examples.
+
 ## Install
 
 Method 1 (recommended): install from PyPI:

--- a/doc/api/input_format.rst
+++ b/doc/api/input_format.rst
@@ -3,7 +3,7 @@
 Note on input format
 ====================
 
-One of the simplest formats to store trajectories is a large table of coordinates.
+saspt expects input trajectories as a large table of spatiotemporal coordinates.
 Each coordinate represents the detection of a single fluorescent emitter, and is 
 associated with a *trajectory index* that has been assigned by a tracking algorithm.
 An example is shown in the figure below.
@@ -18,8 +18,7 @@ An example is shown in the figure below.
     the case of trajectory 3.
 
 The detection table (usually as a CSV) is the format expected by ``saspt``.
-It was chosen for its simplicity; the output of pretty much any tracking algorithm 
-can be converted to a detection CSV.
+This format was chosen for simplicity.
 
 ``saspt`` comes with an example of the kind of input it expects:
 
@@ -38,6 +37,8 @@ can be converted to a detection CSV.
     495  360.006572   70.511980    299       14458
 
     [496 rows x 4 columns]
+
+The XY coordinates in **pixels**.
 
 These can then be used to construct the objects that ``saspt`` expects (see
 the class hierarchy at :ref:`api_label`):

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -29,7 +29,8 @@ We'll use the sample set of trajectories that comes with ``saspt``:
     >>> from saspt import sample_detections, StateArray, RBME
     >>> detections = sample_detections()
 
-(The expected format for input trajectories is described under :ref:`input_format_label`.)
+The expected format for input trajectories is described under :ref:`input_format_label`.
+**Importantly, the units for the XY coordinates are in pixels, not microns.**
 
 Next, we'll set the parameters for a state array that uses mixtures of regular Brownian
 motions with localization error (RBMEs):

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -4,10 +4,10 @@ References
 
 The source code for ``saspt`` is `publicly available <https://github.com/alecheckert/saspt>`_ under an MIT license.
 
-If you use state arrays in your research, please cite the `state array paper <https://www.biorxiv.org/content/10.1101/2021.05.03.442482v1>`_
+If you use state arrays in your research, please cite the `state array paper <https://elifesciences.org/articles/70169>`_
 (currently in preprint):
 
-Heckert A, Dahal D, Tjian R, Darzacq X, "Recovering mixtures of fast diffusing states from short single particle trajectories." *bioRxiv* (2021) https://doi.org/10.1101/2021.05.03.442482
+Alec Heckert, Liza Dahal, Robert Tijan, Xavier Darzacq (2022) **Recovering mixtures of fast-diffusing states from short single-particle trajectories** eLife 11:e70169 (https://doi.org/10.7554/eLife.70169)
 
 The trajectories used in the examples for the ``saspt`` repo were generated 
 using the `quot <https://github.com/alecheckert/quot>`_ tool at

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -12,7 +12,8 @@ def exampleStateArray():
     # Input files containing trajectories
     input_files = glob(os.path.join(SAMPLE_DIR, "u2os_ht_nls_7.48ms", "*.csv"))
 
-    # Load and concatenate detected particles across files
+    # Load and concatenate detected particles across files. The units of
+    # the XY columns are in *pixels*.
     detections = load_detections(*input_files)
 
     # Configuration for the state array, including microscope parameters

--- a/saspt/__init__.py
+++ b/saspt/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 from .constants import RBME, RBME_MARGINAL, GAMMA, FBME, LIKELIHOOD_TYPES
 from .dataset import StateArrayDataset
 from .io import load_detections, concat_detections, sample_detections

--- a/saspt/plot.py
+++ b/saspt/plot.py
@@ -615,20 +615,25 @@ def spatial_assignment_probability_plot(
     # Get localization density
     loc_density = H / bin_area 
 
-    vmin = 0
-    vmax = np.mean([np.nanpercentile(post_mean, 99), np.nanpercentile(prior_mean, 99)])
+    # Colorbar scaling
+    loc_density_vmin = 0
+    loc_density_vmax = np.nanpercentile(loc_density, 99)
+    prior_vmin = 0
+    prior_vmax = np.nanpercentile(prior_mean, 99)
+    post_vmin = 0
+    post_vmax = np.nanpercentile(post_mean, 99)
 
     # Main plot
     fig, ax = plt.subplots(1, 3, figsize=(3*3, 1*3), sharex=True, sharey=True)
-    f0 = ax[0].imshow(loc_density, cmap='gray', origin='lower', vmin=vmin, vmax=vmax)
+    f0 = ax[0].imshow(loc_density, cmap='gray', origin='lower', vmin=loc_density_vmin, vmax=loc_density_vmax)
     cbar = plt.colorbar(f0, ax=ax[0], fraction=0.046, pad=0.04)
     cbar.set_label("Detections / $\mu$m$^{2}$", fontsize=fontsize)
 
-    f1 = ax[1].imshow(prior_mean, cmap='viridis', origin='lower', vmin=vmin, vmax=vmax)
+    f1 = ax[1].imshow(prior_mean, cmap='viridis', origin='lower', vmin=prior_vmin, vmax=prior_vmax)
     cbar = plt.colorbar(f1, ax=ax[1], fraction=0.046, pad=0.04)
     cbar.set_label("Naive mean diff. coef. ($\mu$m$^{2}$ s$^{-1}$)", fontsize=fontsize)
 
-    f2 = ax[2].imshow(post_mean, cmap='viridis', origin='lower', vmin=vmin, vmax=vmax)
+    f2 = ax[2].imshow(post_mean, cmap='viridis', origin='lower', vmin=post_vmin, vmax=post_vmax)
     cbar = plt.colorbar(f2, ax=ax[2], fraction=0.046, pad=0.04)
     cbar.set_label("Posterior mean diff. coef. ($\mu$m$^{2}$ s$^{-1}$)", fontsize=fontsize)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = saspt
-version = 0.2.0
+version = 0.3.0
 author = Alec Heckert
 author_email = alecheckert@gmail.com
 description = State arrays for single particle tracking

--- a/tests/test_defoc.py
+++ b/tests/test_defoc.py
@@ -20,19 +20,16 @@ class TestDefocCorr(unittest.TestCase):
             (self.diff_coefs,),
             (self.diff_coefs,),
             (self.diff_coefs, self.loc_errors),
-            (self.diff_coefs, self.hurst_pars),
+            (self.diff_coefs, self.hurst_pars, self.loc_errors),
         ]
         self.occ_sets = [
             np.random.random(size=(self.n_dc, 0)),
             np.random.random(size=(self.n_dc, 0)),
             np.random.random(size=(self.n_dc, self.n_le, 0)),
-            np.random.random(size=(self.n_dc, self.n_hp, 0)),
+            np.random.random(size=(self.n_dc, self.n_hp, self.n_le, 0)),
         ]
 
         np.random.seed(66666)
-
-    def tearDown(self):
-        pass
 
     def test_normalization(self):
         """ Make sure that *defoc_corr* normalizes its output if the *normalize*
@@ -59,11 +56,11 @@ class TestDefocCorr(unittest.TestCase):
         assert (defoc.defoc_corr(occs[:,:,0], support=support, likelihood=RBME, **self.kwargs).sum() - 1.0) <= 1.0e-6
 
         # FBME
-        support = (self.diff_coefs, self.hurst_pars)
-        occs = np.random.random(size=(self.n_dc, self.n_hp, self.n_tracks))
+        support = (self.diff_coefs, self.hurst_pars, self.loc_errors)
+        occs = np.random.random(size=(self.n_dc, self.n_hp, self.n_le, self.n_tracks))
         result = defoc.defoc_corr(occs, support=support, likelihood=FBME, **self.kwargs)
-        assert (np.abs(result.sum(axis=(0,1)) - 1.0) <= 1.0e-6).all()
-        assert (defoc.defoc_corr(occs[:,:,0], support=support, likelihood=FBME, **self.kwargs).sum() - 1.0) <= 1.0e-6
+        assert (np.abs(result.sum(axis=(0,1,2)) - 1.0) <= 1.0e-6).all()
+        assert (defoc.defoc_corr(occs[:,:,:,0], support=support, likelihood=FBME, **self.kwargs).sum() - 1.0) <= 1.0e-6
 
     def test_inf_focal_depth(self):
         """ All defocalization function should return the input unmodified if passed 

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -91,7 +91,7 @@ class TestLikelihoods(unittest.TestCase):
             RBME: dict(diff_coefs=diff_coefs, loc_errors=loc_errors),
             GAMMA: dict(diff_coefs=diff_coefs),
             RBME_MARGINAL: dict(diff_coefs=diff_coefs, loc_errors=loc_errors),
-            FBME: dict(diff_coefs=diff_coefs, hurst_pars=hurst_pars),
+            FBME: dict(diff_coefs=diff_coefs, hurst_pars=hurst_pars, loc_errors=loc_errors),
         }
 
         for likelihood_type in LIKELIHOODS.keys():


### PR DESCRIPTION
 - Fixes a bug in `StateArray.plot_spatial_assignment_probabilities` that led to the same colorbar scaling for localization density, prior diffusion coefficient, and posterior diffusion coefficient. These all have distinct colorbar scaling now.
 - Adds notes about expected input units (pixels rather than microns).
 - Adds reference to published state array paper.
 - Upgrades the FBME likelihood function to incorporate localization error.